### PR TITLE
Static compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,13 @@ else()
 endif()
 
 # packages
+if(CMAKE_BUILD_TYPE STREQUAL Deploy)
+    set(OPENSSL_USE_STATIC_LIBS ON)
+    set(sodium_USE_STATIC_LIBS ON)
+    set(Readline_USE_STATIC_LIBS ON)
+    set(Boost_USE_MULTITHREADED ON)
+endif()
+
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 find_package(Boost 1.58.0 REQUIRED COMPONENTS
@@ -44,7 +51,7 @@ find_package(sodium 1.0.8 REQUIRED)
 find_package(Readline 5.0 REQUIRED)
 
 set(Protobuf_USE_STATIC_LIBS ON)
-find_package(Protobuf 3.3.0 REQUIRED)
+find_package(Protobuf 3.0.0 REQUIRED)
 
 if(OPENSSL_VERSION VERSION_EQUAL 1.1.0 OR 
     (OPENSSL_VERSION VERSION_GREATER 1.1.0 AND OPENSSL_VERSION VERSION_LESS 1.2.0))
@@ -58,6 +65,7 @@ if(WIN32)
     find_library(WSSOCK32_LIB NAMES wsock32)
 elseif(UNIX AND NOT APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lrt")
+    link_libraries(-ldl)
 endif()
 
 # sub directories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,11 @@ elseif(UNIX AND NOT APPLE)
     link_libraries(-ldl)
 endif()
 
+# warnings
+if (APPLE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility-inlines-hidden -fvisibility=hidden")
+endif()
+
 # sub directories
 add_subdirectory(src)
 add_subdirectory(walleve)

--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -13,7 +13,9 @@ cd build
 
 # cmake
 flag=""
-if [ "$1" == "debug" ]; then
+if [ "$1" == "deploy" ]; then
+    flag="-DCMAKE_BUILD_TYPE=Deploy"
+elif [ "$1" == "debug" ]; then
     flag="-DCMAKE_BUILD_TYPE=Debug"
 else
     flag="-DCMAKE_BUILD_TYPE=Release"
@@ -47,8 +49,5 @@ else
         sudo make install
     fi
 fi
-
-pwd
-cp src/multiverse* ../docker/apps
 
 cd $origin_path

--- a/cmake/FindReadline.cmake
+++ b/cmake/FindReadline.cmake
@@ -17,30 +17,51 @@
 #  Readline_INCLUDE_DIR      The readline include directories. 
 #  Readline_LIBRARY          The readline library.
 
-find_path(Readline_ROOT_DIR
+if(Readline_USE_STATIC_LIBS)
+  set(_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+endif()
+
+if(UNIX AND NOT APPLE)
+  set(root_path "/opt/local/" "/usr/" "/usr/local/")
+else()
+  set(root_path "/usr/local/" "/usr/local/opt")
+endif()
+
+FIND_PATH(Readline_ROOT_DIR
     NAMES include/readline/readline.h
-    PATHS /opt/local/ /usr/local/ /usr/
+    PATHS ${root_path}
+    PATH_SUFFIXES readline
     NO_DEFAULT_PATH
 )
 
-find_path(Readline_INCLUDE_DIR
+FIND_PATH(Readline_INCLUDE_DIR
     NAMES readline/readline.h
     HINTS ${Readline_ROOT_DIR}/include
 )
 
-find_library(Readline_LIBRARY
+FIND_LIBRARY(Readline_LIBRARY
     NAMES readline
     HINTS ${Readline_ROOT_DIR}/lib
 )
 
-if(Readline_INCLUDE_DIR AND Readline_LIBRARY AND Ncurses_LIBRARY)
-  set(READLINE_FOUND TRUE)
-else(Readline_INCLUDE_DIR AND Readline_LIBRARY AND Ncurses_LIBRARY)
-  FIND_LIBRARY(Readline_LIBRARY NAMES readline)
-  include(FindPackageHandleStandardArgs)
-  FIND_PACKAGE_HANDLE_STANDARD_ARGS(Readline DEFAULT_MSG Readline_INCLUDE_DIR Readline_LIBRARY )
-  MARK_AS_ADVANCED(Readline_INCLUDE_DIR Readline_LIBRARY)
-endif(Readline_INCLUDE_DIR AND Readline_LIBRARY AND Ncurses_LIBRARY)
+FIND_PATH(Ncurses_ROOT_DIR
+    NAMES include/ncurses.h
+    PATHS ${root_path}
+    PATH_SUFFIXES ncurses
+    NO_DEFAULT_PATH
+)
+
+FIND_LIBRARY(Ncurses_LIBRARY
+  NAMES tinfo termcap ncursesw ncurses cursesw curses
+  HINTS ${Ncurses_ROOT_DIR}/lib
+)
+
+if(NOT Ncurses_LIBRARY)
+  message(FATAL_ERROR "ncurses library not found")
+endif()
+
+set(Readline_LIBRARY ${Readline_LIBRARY} ${Ncurses_LIBRARY})
 
 if (EXISTS "${Readline_INCLUDE_DIR}/readline/readline.h")
   file(STRINGS "${Readline_INCLUDE_DIR}/readline/readline.h" readline_h_content
@@ -49,7 +70,11 @@ if (EXISTS "${Readline_INCLUDE_DIR}/readline/readline.h")
                         READLINE_VERSION ${readline_h_content})
   string(REGEX REPLACE "^0" "" READLINE_VERSION ${READLINE_VERSION})
   string(REPLACE ".0" "." READLINE_VERSION ${READLINE_VERSION})
-endif ()
+endif()
+
+if(Readline_USE_STATIC_LIBS)
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${_CMAKE_FIND_LIBRARY_SUFFIXES})
+endif()
 
 # communicate results
 include(FindPackageHandleStandardArgs)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,8 +25,14 @@ target_link_libraries(test_fnfn
 	Boost::unit_test_framework
 	Boost::system
 	Boost::thread
-	mpvss
-	crypto
+    OpenSSL::SSL
+    OpenSSL::Crypto
+    mpvss
+    crypto
+    walleve
+    storage    
+    network
+    common
 )
 
 add_executable(test_ctsdb test_fnfn_main.cpp test_fnfn.h test_fnfn.cpp ctsdb_test.cpp)


### PR DESCRIPTION
 - Support static compilation by "cmake -DCMAKE_BUILD_TYPE=Deploy" or "./INSTALL.sh deploy"
 - Fix linking warning on MacOS

Complete issue #4 