### PR TITLE
Fix wallet sequence bug

### DIFF
--- a/storage/walletdb.cpp
+++ b/storage/walletdb.cpp
@@ -145,7 +145,7 @@ bool CWalletTxDB::AddNewTx(const CWalletTx& wtx)
     }
 
     if (!Write(make_pair(string("wtx"),wtx.txid),pairWalletTx)
-        || !Write(make_pair(string("seq"),pairWalletTx.first),CWalletTxSeq(wtx))
+        || !Write(make_pair(string("seq"),BSwap64(pairWalletTx.first)),CWalletTxSeq(wtx))
         || !Write(string("txcount"),nTxCount + 1)
         || !Write(string("sequence"),nSequence))
     {
@@ -204,7 +204,7 @@ bool CWalletTxDB::UpdateTx(const vector<CWalletTx>& vWalletTx,const vector<uint2
     {
         pair<uint64,CWalletTx>& pairWalletTx = vTxUpdate[i];
         if (!Write(make_pair(string("wtx"),pairWalletTx.second.txid),pairWalletTx)
-            || !Write(make_pair(string("seq"),pairWalletTx.first),CWalletTxSeq(pairWalletTx.second)))
+            || !Write(make_pair(string("seq"),BSwap64(pairWalletTx.first)),CWalletTxSeq(pairWalletTx.second)))
         {
             TxnAbort();
             return false;
@@ -214,7 +214,7 @@ bool CWalletTxDB::UpdateTx(const vector<CWalletTx>& vWalletTx,const vector<uint2
     for (int i = 0;i < vTxRemove.size();i++)
     {
         if (!Erase(make_pair(string("wtx"),vTxRemove[i].second))
-            || !Erase(make_pair(string("seq"),vTxRemove[i].first)))
+            || !Erase(make_pair(string("seq"),BSwap64(vTxRemove[i].first))))
         {
             TxnAbort();
             return false;
@@ -263,13 +263,13 @@ size_t CWalletTxDB::GetTxCount()
 bool CWalletTxDB::WalkThroughTxSeq(CWalletDBTxSeqWalker& walker)
 {
     return WalkThrough(boost::bind(&CWalletTxDB::TxSeqWalker,this,_1,_2,boost::ref(walker)),
-                       make_pair(string("seq"),uint64(0)));
+                       make_pair(string("seq"),BSwap64(uint64(0))));
 }
 
 bool CWalletTxDB::WalkThroughTx(CWalletDBTxWalker& walker)
 {
     return WalkThrough(boost::bind(&CWalletTxDB::TxWalker,this,_1,_2,boost::ref(walker)),
-                       make_pair(string("seq"),uint64(0)));
+                       make_pair(string("seq"),BSwap64(uint64(0))));
 }
 
 bool CWalletTxDB::TxSeqWalker(CWalleveBufStream& ssKey,CWalleveBufStream& ssValue,CWalletDBTxSeqWalker& walker)

--- a/walleve/walleve/util.h
+++ b/walleve/walleve/util.h
@@ -303,6 +303,13 @@ inline const char* TypeName(const std::type_info& info)
 }
 #endif
 
+inline uint64 BSwap64(uint64 n)
+{
+    n = ((n & 0xff00ff00ff00ff00ULL) >> 8) | ((n & 0x00ff00ff00ff00ffULL) << 8);
+    n = ((n & 0xffff0000ffff0000ULL) >> 16) | ((n & 0x0000ffff0000ffffULL) << 16);
+    return (n >> 32) | (n << 32);
+}
+
 } // namespace walleve
 
 #endif //WALLEVE_UTIL_H


### PR DESCRIPTION
Save sequence number with big-endian for LevelDB compare